### PR TITLE
Fix: Unsupported cell type 'null'

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
@@ -96,7 +96,7 @@ public class StreamingCell implements Cell {
    */
   @Override
   public int getCellType() {
-    if (contents == null) {
+    if (contents == null || type == null) {
       return Cell.CELL_TYPE_BLANK;
     } else if ("n".equals(type)) {
       return Cell.CELL_TYPE_NUMERIC;


### PR DESCRIPTION
Fixing UnsupportedOperationException if type is null!

Sometimes 'type' variable was null, I don't know why, but occorred with all my xlsx files in some Cell's
So, I changed the code and worked for me and all my team.