### PR TITLE
Fix to consider cell styles

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/StreamingReader.java
+++ b/src/main/java/com/monitorjbl/xlsx/StreamingReader.java
@@ -1,11 +1,14 @@
 package com.monitorjbl.xlsx;
 
+import org.apache.poi.ss.usermodel.BuiltinFormats;
+import org.apache.poi.ss.usermodel.DataFormatter;
 import com.monitorjbl.xlsx.exceptions.CloseException;
 import com.monitorjbl.xlsx.exceptions.MissingSheetException;
 import com.monitorjbl.xlsx.exceptions.OpenException;
 import com.monitorjbl.xlsx.exceptions.ReadException;
 import com.monitorjbl.xlsx.impl.StreamingCell;
 import com.monitorjbl.xlsx.impl.StreamingRow;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
@@ -13,6 +16,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.util.CellReference;
 import org.apache.poi.xssf.eventusermodel.XSSFReader;
 import org.apache.poi.xssf.model.SharedStringsTable;
+import org.apache.poi.xssf.model.StylesTable;
 import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +66,19 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
 
   private File tmp;
 
-  private StreamingReader(SharedStringsTable sst, XMLEventReader parser, int rowCacheSize) {
+   /**
+    * <CODE>StylesTable</CODE> used to determine how to format numeric cell
+    * values.
+    */
+   private StylesTable stylesTable = null;
+
+   /**
+    * <CODE>DataFormatter</CODE> used to format numeric cell values.
+    */
+   private final DataFormatter dataFormatter = new DataFormatter();
+
+  private StreamingReader(StylesTable styles, SharedStringsTable sst, XMLEventReader parser, int rowCacheSize) {
+     this.stylesTable = styles;
     this.sst = sst;
     this.parser = parser;
     this.rowCacheSize = rowCacheSize;
@@ -100,7 +116,7 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
     } else if (event.getEventType() == XMLStreamConstants.START_ELEMENT) {
       StartElement startElement = event.asStartElement();
       String tagLocalName = startElement.getName().getLocalPart();
-      
+
       if ("row".equals(tagLocalName)) {
         Attribute rowIndex = startElement.getAttributeByName(new QName("r"));
         currentRow = new StreamingRow(Integer.parseInt(rowIndex.getValue()));
@@ -110,12 +126,59 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
         String[] coord = ref.getValue().split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)");
         currentCell = new StreamingCell(CellReference.convertColStringToIndex(coord[0]), Integer.parseInt(coord[1]) - 1);
 
-        Attribute type = startElement.getAttributeByName(new QName("t"));
-        if(type != null) {
-          currentCell.setType(type.getValue());
-        }
+         Attribute type = startElement.getAttributeByName(new QName("t"));
+/*ForgetMeNot--ibell--20150911--old code which didn't determine numeric vs date data types.
+         if(type != null) {
+            currentCell.setType(type.getValue());
+         }
+*/
+         //
+         // This block will determine the value type and set the appropriate
+         // XSSF data type (used to format numeric cell values).
+         //
+         final String typeValue = (type != null) ? type.getValue() : "";
+         if ("b".equals(typeValue)) {
+            currentCell.setXssfDataType(StreamingCell.XSSF_DATA_TYPE.BOOLEAN);
+         } else if ("e".equals(typeValue)) {
+            currentCell.setXssfDataType(StreamingCell.XSSF_DATA_TYPE.ERROR);
+         } else if ("str".equals(typeValue)) {
+            currentCell.setXssfDataType(StreamingCell.XSSF_DATA_TYPE.FORMULA);
+         } else if ("inlineStr".equals(typeValue)) {
+            currentCell.setXssfDataType(StreamingCell.XSSF_DATA_TYPE.INLINE_STRING);
+         } else if ("s".equals(typeValue)) {
+            currentCell.setXssfDataType(StreamingCell.XSSF_DATA_TYPE.SST_INDEX);
+
+         } else {
+            //
+            // The cell type is numeric, so need to determine and store the cell
+            // style and format.
+            //
+            currentCell.setXssfDataType(StreamingCell.XSSF_DATA_TYPE.NUMBER);
+
+            Attribute cellStyle = startElement.getAttributeByName(new QName("s"));
+            final String cellStyleString = (cellStyle != null) ? cellStyle.getValue() : null;
+
+            XSSFCellStyle style = null;
+
+            if (cellStyleString != null) {
+               style = stylesTable.getStyleAt(Integer.parseInt(cellStyleString));
+            } else if (stylesTable.getNumCellStyles() > 0) {
+               style = stylesTable.getStyleAt(0);
+            }
+
+            if (style != null) {
+               currentCell.setNumericFormatIndex(style.getDataFormat());
+               final String formatString = style.getDataFormatString();
+
+               if (formatString != null) {
+                  currentCell.setNumericFormatString(formatString);
+               } else {
+                  currentCell.setNumericFormatString(BuiltinFormats.getBuiltinFormat(currentCell.getNumericFormatIndex()));
+               }
+            }
+         }
       }
-      
+
       // Clear contents cache
       lastContents = "";
     } else if (event.getEventType() == XMLStreamConstants.END_ELEMENT) {
@@ -123,11 +186,69 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
       String tagLocalName = endElement.getName().getLocalPart();
 
       if ("v".equals(tagLocalName)) {
+/*ForgetMeNot--ibell--20150911--old code which didn't determine numeric vs date data types.
         if ("s".equals(currentCell.getType())) {
           int idx = Integer.parseInt(lastContents);
           lastContents = new XSSFRichTextString(sst.getEntryAt(idx)).toString();
         }
         currentCell.setContents(lastContents);
+*/
+         //
+         // This block will format the numeric cell value based on the its XSSF
+         // data type.
+         //
+         String cellValue = null;
+         switch (currentCell.getXssfDataType()) {
+            case BOOLEAN:
+               char first = lastContents.charAt(0);
+               cellValue = first == '0' ? "FALSE" : "TRUE";
+               break;
+
+            case ERROR:
+               cellValue = "\"ERROR:  " + lastContents + '"';
+               break;
+
+            case FORMULA:
+               //
+               // A formula could result in a string value, so always add
+               // double-quote characters.
+               //
+               cellValue = '"' + lastContents + '"';
+               break;
+
+            case INLINE_STRING:
+               //
+               // have not seen an example of this, so it's untested.
+               //
+               XSSFRichTextString rtsi = new XSSFRichTextString(lastContents);
+               cellValue = '"' + rtsi.toString() + '"';
+               break;
+
+            case SST_INDEX:
+               try {
+                  int idx = Integer.parseInt(lastContents);
+                  XSSFRichTextString rtss = new XSSFRichTextString(this.sst.getEntryAt(idx));
+                  cellValue = '"' + rtss.toString() + '"';
+               } catch (java.lang.NumberFormatException nfe) {
+                  cellValue = "\"ERROR:  Failed to parse SST index '" + lastContents + "':  " + nfe.toString() + '"';
+               }
+               break;
+
+            case NUMBER:
+               final String formatString = currentCell.getNumericFormatString();
+               if (formatString != null && lastContents.length() > 0) {
+                  cellValue = this.dataFormatter.formatRawCellContents(Double.parseDouble(lastContents), currentCell.getNumericFormatIndex(), formatString);
+               } else {
+                  cellValue = lastContents;
+               }
+               break;
+
+            default:
+               cellValue = "\"ERROR:  Unexpected cell type:  " + currentCell.getXssfDataType() + '"';
+               break;
+         }
+
+         currentCell.setContents(cellValue);
       } else if ("row".equals(tagLocalName) && currentRow != null) {
         rowCache.add(currentRow);
       } else if ("c".equals(tagLocalName)) {
@@ -293,6 +414,7 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
       try {
         OPCPackage pkg = OPCPackage.open(f);
         XSSFReader reader = new XSSFReader(pkg);
+        StylesTable styles = reader.getStylesTable();
         SharedStringsTable sst = reader.getSharedStringsTable();
 
         InputStream sheet = findSheet(reader);
@@ -301,7 +423,7 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
         }
 
         XMLEventReader parser = XMLInputFactory.newInstance().createXMLEventReader(sheet);
-        return new StreamingReader(sst, parser, rowCacheSize);
+        return new StreamingReader(styles, sst, parser, rowCacheSize);
       } catch (IOException e) {
         throw new OpenException("Failed to open file", e);
       } catch (OpenXML4JException | XMLStreamException e) {

--- a/src/main/java/com/monitorjbl/xlsx/StreamingReader.java
+++ b/src/main/java/com/monitorjbl/xlsx/StreamingReader.java
@@ -154,7 +154,7 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
           //
           currentCell.setXssfDataType(StreamingCell.XSSF_DATA_TYPE.NUMBER);
 
-          Attribute cellStyle = startElement.getAttributeByName(new QName("s"));
+          final Attribute cellStyle = startElement.getAttributeByName(new QName("s"));
           final String cellStyleString = (cellStyle != null) ? cellStyle.getValue() : null;
 
           XSSFCellStyle style = null;
@@ -177,7 +177,7 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
           }
         }
       }
-      
+
       // Clear contents cache
       lastContents = "";
     } else if (event.getEventType() == XMLStreamConstants.END_ELEMENT) {
@@ -199,12 +199,11 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
         String cellValue = null;
         switch (currentCell.getXssfDataType()) {
           case BOOLEAN:
-            char first = lastContents.charAt(0);
-            cellValue = first == '0' ? "FALSE" : "TRUE";
+            cellValue = (lastContents.charAt(0) == '0') ? "false" : "true";
             break;
 
           case ERROR:
-            cellValue = "\"ERROR:  " + lastContents + '"';
+            cellValue = "ERROR:  " + lastContents;
             break;
 
           case FORMULA:
@@ -219,17 +218,15 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
             //
             // have not seen an example of this, so it's untested.
             //
-            XSSFRichTextString rtsi = new XSSFRichTextString(lastContents);
-            cellValue = '"' + rtsi.toString() + '"';
+            cellValue = new XSSFRichTextString(lastContents).toString();
             break;
 
           case SST_INDEX:
             try {
-              int idx = Integer.parseInt(lastContents);
-              XSSFRichTextString rtss = new XSSFRichTextString(this.sst.getEntryAt(idx));
-              cellValue = '"' + rtss.toString() + '"';
+              final int idx = Integer.parseInt(lastContents);
+              cellValue = new XSSFRichTextString(this.sst.getEntryAt(idx)).toString();
             } catch (java.lang.NumberFormatException nfe) {
-              cellValue = "\"ERROR:  Failed to parse SST index '" + lastContents + "':  " + nfe.toString() + '"';
+              cellValue = "ERROR:  Failed to parse SST index '" + lastContents + "':  " + nfe.toString();
             }
             break;
 
@@ -243,7 +240,7 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
             break;
 
           default:
-            cellValue = "\"ERROR:  Unexpected cell type:  " + currentCell.getXssfDataType() + '"';
+            cellValue = "ERROR:  Unexpected cell type:  " + currentCell.getXssfDataType();
             break;
         }
 

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
@@ -248,6 +248,7 @@ public class StreamingCell implements Cell {
   /**
    * Not supported.  Added for compatability with POI 3.12.
    */
+  @Override
   public void removeHyperlink() {
     throw new NotSupportedException();
   }

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
@@ -28,12 +28,12 @@ public class StreamingCell implements Cell {
    * cell.  The value is usually in a "v" element within the cell.
    */
   public static enum XSSF_DATA_TYPE {
-     BOOLEAN,
-     ERROR,
-     FORMULA,
-     INLINE_STRING,
-     NUMBER,
-     SST_INDEX
+    BOOLEAN,
+    ERROR,
+    FORMULA,
+    INLINE_STRING,
+    NUMBER,
+    SST_INDEX
   }
 
   /**
@@ -89,7 +89,7 @@ public class StreamingCell implements Cell {
    *         cell value instead of the raw one.
    */
   public XSSF_DATA_TYPE getXssfDataType() {
-     return xssfDataType;
+    return xssfDataType;
   }
 
   /**
@@ -100,7 +100,7 @@ public class StreamingCell implements Cell {
    *        the actual cell value instead of the raw one.
    */
   public void setXssfDataType(XSSF_DATA_TYPE xssfDataType) {
-     this.xssfDataType = xssfDataType;
+    this.xssfDataType = xssfDataType;
   }
 
   /**
@@ -111,7 +111,7 @@ public class StreamingCell implements Cell {
    *         <CODE>StylesTable</CODE> to format numeric cell values.
    */
   public Short getNumericFormatIndex() {
-     return numericFormatIndex;
+    return numericFormatIndex;
   }
 
   /**
@@ -122,7 +122,7 @@ public class StreamingCell implements Cell {
    *        in a <CODE>StylesTable</CODE> to format numeric cell values.
    */
   public void setNumericFormatIndex(Short numericFormatIndex) {
-     this.numericFormatIndex = numericFormatIndex;
+    this.numericFormatIndex = numericFormatIndex;
   }
 
   /**
@@ -133,7 +133,7 @@ public class StreamingCell implements Cell {
    *         <CODE>numericFormatIndex</CODE> to format a numeric cell value.
    */
   public String getNumericFormatString() {
-     return numericFormatString;
+    return numericFormatString;
   }
 
   /**
@@ -145,7 +145,7 @@ public class StreamingCell implements Cell {
    *        numeric cell value.
    */
   public void setNumericFormatString(String numericFormatString) {
-     this.numericFormatString = numericFormatString;
+    this.numericFormatString = numericFormatString;
   }
 
   /* Supported */

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
@@ -23,6 +23,39 @@ public class StreamingCell implements Cell {
   private String type;
   private Row row;
 
+  /**
+   * The cell type of the data value is indicated by an attribute on the
+   * cell.  The value is usually in a "v" element within the cell.
+   */
+  public static enum XSSF_DATA_TYPE {
+     BOOLEAN,
+     ERROR,
+     FORMULA,
+     INLINE_STRING,
+     NUMBER,
+     SST_INDEX
+  }
+
+  /**
+   * Used to format the actual Excel spreadsheet cell value, instead of the raw
+   * one.
+   */
+  private XSSF_DATA_TYPE xssfDataType = null;
+
+  /**
+   * The style index, used to look up a built-in style in a
+   * <CODE>StylesTable</CODE> to format numeric cell values.
+   */
+  private Short numericFormatIndex = null;
+
+  /**
+   * The format <CODE>String</CODE> used in conjunction with the
+   * <CODE>numericFormatIndex</CODE> to format a numeric cell value.
+   *
+   * @see numericFormatIndex
+   */
+  private String numericFormatString = null;
+
   public StreamingCell(int columnIndex, int rowIndex) {
     this.columnIndex = columnIndex;
     this.rowIndex = rowIndex;
@@ -46,6 +79,73 @@ public class StreamingCell implements Cell {
 
   public void setRow(Row row) {
     this.row = row;
+  }
+
+  /**
+   * Return the Excel XSSF spreadsheet cell type, used to determine the actual
+   * cell value instead of the raw one.
+   *
+   * @return the Excel XSSF spreadsheet cell type, used to determine the actual
+   *         cell value instead of the raw one.
+   */
+  public XSSF_DATA_TYPE getXssfDataType() {
+     return xssfDataType;
+  }
+
+  /**
+   * Set the Excel XSSF spreadsheet cell type, used to determine the actual
+   * cell value instead of the raw one.
+   *
+   * @param xssfDataType the Excel XSSF spreadsheet cell type, used to determine
+   *        the actual cell value instead of the raw one.
+   */
+  public void setXssfDataType(XSSF_DATA_TYPE xssfDataType) {
+     this.xssfDataType = xssfDataType;
+  }
+
+  /**
+   * Return the style index, used to look up a built-in style in a
+   * <CODE>StylesTable</CODE> to format numeric cell values.
+   *
+   * @return the style index, used to look up a built-in style in a
+   *         <CODE>StylesTable</CODE> to format numeric cell values.
+   */
+  public Short getNumericFormatIndex() {
+     return numericFormatIndex;
+  }
+
+  /**
+   * Set the style index, used to look up a built-in style in a
+   * <CODE>StylesTable</CODE> to format numeric cell values.
+   *
+   * @param numericFormatIndex the style index, used to look up a built-in style
+   *        in a <CODE>StylesTable</CODE> to format numeric cell values.
+   */
+  public void setNumericFormatIndex(Short numericFormatIndex) {
+     this.numericFormatIndex = numericFormatIndex;
+  }
+
+  /**
+   * Return the format <CODE>String</CODE> used in conjunction with the
+   * <CODE>numericFormatIndex</CODE> to format a numeric cell value.
+   *
+   * @return the format <CODE>String</CODE> used in conjunction with the
+   *         <CODE>numericFormatIndex</CODE> to format a numeric cell value.
+   */
+  public String getNumericFormatString() {
+     return numericFormatString;
+  }
+
+  /**
+   * Set the format <CODE>String</CODE> used in conjunction with the
+   * <CODE>numericFormatIndex</CODE> to format a numeric cell value.
+   *
+   * @param numericFormatString the format <CODE>String</CODE> used in
+   *        conjunction with the <CODE>numericFormatIndex</CODE> to format a
+   *        numeric cell value.
+   */
+  public void setNumericFormatString(String numericFormatString) {
+     this.numericFormatString = numericFormatString;
   }
 
   /* Supported */

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
@@ -246,6 +246,13 @@ public class StreamingCell implements Cell {
   /* Not supported */
 
   /**
+   * Not supported.  Added for compatability with POI 3.12.
+   */
+  public void removeHyperlink() {
+    throw new NotSupportedException();
+  }
+
+  /**
    * Not supported
    */
   @Override

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingRow.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingRow.java
@@ -87,6 +87,7 @@ public class StreamingRow implements Row {
   /**
    * Not supported.  Added for compatability with POI 3.12.
    */
+  @Override
   public int getOutlineLevel() {
     throw new NotSupportedException();
   }

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingRow.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingRow.java
@@ -85,6 +85,13 @@ public class StreamingRow implements Row {
   }
 
   /**
+   * Not supported.  Added for compatability with POI 3.12.
+   */
+  public int getOutlineLevel() {
+    throw new NotSupportedException();
+  }
+
+  /**
    * Not supported
    */
   @Override


### PR DESCRIPTION
Original solution skipped the styles, which caused date fields to be
returned as days since epoch time, instead of a formatted date.  There
was no way to determine which cells were actual numbers and which were
dates (w/o assuming).

Found a solution in
http://poi.apache.org/spreadsheet/how-to.html#xssf_sax_api, specifically
a link to
https://svn.apache.org/repos/asf/poi/trunk/src/examples/src/org/apache/poi/xssf/eventusermodel/XLSX2CSV.java.
Adapted that solution to your's to no longer ignore cell styles.

There is probably a more elegant solution, using the StreamingCell's
getCellType(), getStringCellValue(), getDateCellValue(), et. al.; but I
had to get this working in < 1 day.  So, I offer this as a temporary fix
until a more elegant solution can be found for using the other
StreamingCell methods/fields in the StreamingReader.