### PR TITLE
currentCell.getType() Null type

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/StreamingReader.java
+++ b/src/main/java/com/monitorjbl/xlsx/StreamingReader.java
@@ -184,7 +184,7 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
    * @return
    */
   String formattedContents() {
-    switch(currentCell.getType()) {
+    switch(currentCell.getType() == null ? "" : currentCell.getType()) {
       case "s":           //string stored in shared table
         int idx = Integer.parseInt(lastContents);
         return new XSSFRichTextString(sst.getEntryAt(idx)).toString();
@@ -213,7 +213,7 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
    * @return
    */
   String unformattedContents(){
-    switch(currentCell.getType()) {
+    switch(currentCell.getType() == null ? "" : currentCell.getType()) {
       case "s":           //string stored in shared table
         int idx = Integer.parseInt(lastContents);
         return new XSSFRichTextString(sst.getEntryAt(idx)).toString();


### PR DESCRIPTION
If currentCell.getType() is null, the switch will throw a NPE.