### PR TITLE
Added support for sheet.getLastRowNum()

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheet.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheet.java
@@ -115,11 +115,13 @@ public class StreamingSheet implements Sheet {
   }
 
   /**
-   * Not supported
+   * Gets the last row on the sheet
+   *
+   * @return last row contained n this sheet (0-based)
    */
   @Override
   public int getLastRowNum() {
-    throw new UnsupportedOperationException();
+    return reader.getLastRowNum();
   }
 
   /**

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheetReader.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheetReader.java
@@ -42,7 +42,6 @@ public class StreamingSheetReader implements Iterable<Row> {
   private final DataFormatter dataFormatter = new DataFormatter();
   private final Set<Integer> hiddenColumns = new HashSet<>();
 
-  private boolean headerRead;
   private int lastRowNum;
   private int rowCacheSize;
   private List<Row> rowCache = new ArrayList<>();
@@ -59,34 +58,6 @@ public class StreamingSheetReader implements Iterable<Row> {
     this.rowCacheSize = rowCacheSize;
   }
 
-  private void readSheetHeader() throws XMLStreamException {
-    while (parser.hasNext()) {
-      XMLEvent event = parser.nextEvent();
-      if(event.getEventType() == XMLStreamConstants.START_ELEMENT) {
-        StartElement startElement = event.asStartElement();
-        String tagLocalName = startElement.getName().getLocalPart();
-        if ("dimension".equals(tagLocalName)) {
-          Attribute refAttr = startElement.getAttributeByName(new QName("ref"));
-          String ref = refAttr!=null?refAttr.getValue():null;
-          if (ref!=null) {
-            // ref is formatted as A1 or A1:F25. Take the last numbers of this string and use it as lastRowNum
-            for (int i=ref.length()-1;i>=0;i--) {
-              if (!Character.isDigit(ref.charAt(i))) {
-              try {
-                  lastRowNum = Integer.parseInt(ref.substring(i+1)) - 1;
-              } catch (NumberFormatException ignore) { }
-                break;
-              }
-            }
-          }
-        } else if("sheetData".equals(tagLocalName)) {
-          break;
-        }
-      }
-    }
-    headerRead = true;
-  }
-
   /**
    * Read through a number of rows equal to the rowCacheSize field or until there is no more data to read
    *
@@ -95,8 +66,6 @@ public class StreamingSheetReader implements Iterable<Row> {
   private boolean getRow() {
     try {
       rowCache.clear();
-      if (!headerRead)
-        readSheetHeader();
       while(rowCache.size() < rowCacheSize && parser.hasNext()) {
         handleEvent(parser.nextEvent());
       }
@@ -163,6 +132,20 @@ public class StreamingSheetReader implements Iterable<Row> {
             log.warn("Ignoring invalid style index {}", indexStr);
           }
         }
+      } else if ("dimension".equals(tagLocalName)) {
+        Attribute refAttr = startElement.getAttributeByName(new QName("ref"));
+        String ref = refAttr!=null?refAttr.getValue():null;
+        if (ref!=null) {
+          // ref is formatted as A1 or A1:F25. Take the last numbers of this string and use it as lastRowNum
+          for (int i=ref.length()-1;i>=0;i--) {
+            if (!Character.isDigit(ref.charAt(i))) {
+            try {
+                lastRowNum = Integer.parseInt(ref.substring(i+1)) - 1;
+            } catch (NumberFormatException ignore) { }
+              break;
+            }
+          }
+        }
       }
 
       // Clear contents cache
@@ -202,12 +185,8 @@ public class StreamingSheetReader implements Iterable<Row> {
    * @return
    */
   int getLastRowNum() {
-    if (!headerRead) {
-      try {
-        readSheetHeader();
-      } catch (XMLStreamException e) {
-        log.debug("could not read header");
-      }
+    if(rowCacheIterator == null) {
+      getRow();
     }
     return lastRowNum;
   }

--- a/src/test/java/com/monitorjbl/xlsx/StreamingSheetTest.java
+++ b/src/test/java/com/monitorjbl/xlsx/StreamingSheetTest.java
@@ -1,0 +1,42 @@
+package com.monitorjbl.xlsx;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Locale;
+
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class StreamingSheetTest {
+  @BeforeClass
+  public static void init() {
+    Locale.setDefault(Locale.ENGLISH);
+  }
+
+  @Test
+  public void testLastRowNum() throws Exception {
+    try(
+        InputStream is = new FileInputStream(new File("src/test/resources/large.xlsx"));
+        Workbook workbook = StreamingReader.builder().open(is);
+    ) {
+      assertEquals(1, workbook.getNumberOfSheets());
+      Sheet sheet = workbook.getSheetAt(0);
+      assertEquals(24, sheet.getLastRowNum());
+    }
+
+    try(
+        InputStream is = new FileInputStream(new File("src/test/resources/empty_sheet.xlsx"));
+        Workbook workbook = StreamingReader.builder().open(is);
+    ) {
+      assertEquals(1, workbook.getNumberOfSheets());
+      Sheet sheet = workbook.getSheetAt(0);
+      assertEquals(0, sheet.getLastRowNum());
+    }
+  }
+
+}


### PR DESCRIPTION
Hello,

Great work on this project, it really simplifies reading a workbook which used to be pretty low-level.

This pull request is regarding adding support for getLastRowNum. I specifically aimed on this method as it is used to report the total number of rows back to the user. This can in turn be used to show a progress bar and estimate remaining time.

It basically picks the ref attribute from the dimension element at the top of a sheet. This is formatted as 'A1' or A1:A3000'. Either way, we're only interested in the last number (and subtract 1 so that we get a 0-based row index).

The implementation of StreamingSheetReader.handleEvent captures this 'dimension' element.
A test case was added that tests a sheet with rows, as well as a sheet containing only one row.

Hope you like it :)

(edit: re-opened this pull request as it appeared to break a test ... what was I thinking? probably time for weekend!)