### PR TITLE
Handle Cells without defined style.

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheetReader.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheetReader.java
@@ -1,6 +1,26 @@
 package com.monitorjbl.xlsx.impl;
 
-import com.monitorjbl.xlsx.exceptions.CloseException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
 import org.apache.poi.ss.usermodel.BuiltinFormats;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Row;
@@ -13,25 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLEventReader;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.events.Attribute;
-import javax.xml.stream.events.Characters;
-import javax.xml.stream.events.EndElement;
-import javax.xml.stream.events.StartElement;
-import javax.xml.stream.events.XMLEvent;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import com.monitorjbl.xlsx.exceptions.CloseException;
 
 public class StreamingSheetReader implements Iterable<Row> {
   private static final Logger log = LoggerFactory.getLogger(StreamingSheetReader.class);
@@ -134,6 +136,8 @@ public class StreamingSheetReader implements Iterable<Row> {
           } catch(NumberFormatException nfe) {
             log.warn("Ignoring invalid style index {}", indexStr);
           }
+        } else {
+          currentCell.setCellStyle(stylesTable.getStyleAt(0));
         }
       } else if("dimension".equals(tagLocalName)) {
         Attribute refAttr = startElement.getAttributeByName(new QName("ref"));

--- a/src/test/java/com/monitorjbl/xlsx/StreamingSheetTest.java
+++ b/src/test/java/com/monitorjbl/xlsx/StreamingSheetTest.java
@@ -1,12 +1,15 @@
 package com.monitorjbl.xlsx;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Locale;
 
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.junit.BeforeClass;
@@ -36,6 +39,20 @@ public class StreamingSheetTest {
       assertEquals(1, workbook.getNumberOfSheets());
       Sheet sheet = workbook.getSheetAt(0);
       assertEquals(0, sheet.getLastRowNum());
+    }
+  }
+
+  @Test
+  public void testEmptyCellShouldHaveGeneralStyle() throws Exception {
+    try(
+        InputStream is = new FileInputStream(new File("src/test/resources/large.xlsx"));
+        Workbook workbook = StreamingReader.builder().open(is);
+    ) {
+      assertEquals(1, workbook.getNumberOfSheets());
+      Sheet sheet = workbook.getSheetAt(0);
+      Row row = sheet.iterator().next();
+      assertEquals(CellType.NUMERIC, row.getCell(0).getCellTypeEnum());
+      assertNotNull(row.getCell(0).getCellStyle());
     }
   }
 


### PR DESCRIPTION
If the Cell has no defined style, return the default style of the Workbook.

For example if a cell is formatted under the "General" category, its style instead of being General it ended up being 'Null'.
This PR adds defines the Cell style to the Workbooks default as Excel does. 