### PR TITLE
remove "ooxml-schemas 1.3" from dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,11 +116,6 @@
       <version>3.16</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.poi</groupId>
-      <artifactId>ooxml-schemas</artifactId>
-      <version>1.3</version>
-    </dependency>
-    <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
       <version>2.11.0</version>


### PR DESCRIPTION
"poi-ooxml 3.16" depends on "poi-ooxml-schemas 3.16" and conflicts with "ooxml-schemas 1.3".