### PR TITLE
Fix an issue causing errors about bad return types

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheet.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheet.java
@@ -1,6 +1,6 @@
 package com.monitorjbl.xlsx.impl;
 
-import org.apache.poi.hssf.util.PaneInformation;
+import org.apache.poi.ss.util.PaneInformation;
 import org.apache.poi.ss.usermodel.AutoFilter;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellRange;


### PR DESCRIPTION
When trying to read an xlsx file, a java.lang.VerifyError is thrown saying that com.monitorjbl.clsc.impl.StreamingSheet.getPaneInformation expects to have a return type of org.apache.poi.hssf.util.PaneInformation but is getting org.apache.poi.ss.util.PaneInformation. This change should fix the issue.