### PR TITLE
Optimized based on output from profiler on large sheets

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
@@ -20,6 +20,13 @@ import java.util.Date;
 
 public class StreamingCell implements Cell {
 
+  private static final Supplier NULL_SUPPLIER = new Supplier() {
+    @Override
+    public Object getContent() {
+      return null;
+    }
+  };
+
   private static final String FALSE_AS_STRING = "0";
   private static final String TRUE_AS_STRING  = "1";
 
@@ -27,7 +34,7 @@ public class StreamingCell implements Cell {
   private int rowIndex;
   private final boolean use1904Dates;
 
-  private Object contents;
+  private Supplier contentsSupplier = NULL_SUPPLIER;
   private Object rawContents;
   private String formula;
   private String numericFormat;
@@ -43,16 +50,8 @@ public class StreamingCell implements Cell {
     this.use1904Dates = use1904Dates;
   }
 
-  public Object getContents() {
-    return contents;
-  }
-
-  public void setContents(Object contents) {
-    this.contents = contents;
-  }
-
-  public Object getRawContents() {
-    return rawContents;
+  public void setContentSupplier(Supplier contentsSupplier) {
+    this.contentsSupplier = contentsSupplier;
   }
 
   public void setRawContents(Object rawContents) {
@@ -154,7 +153,7 @@ public class StreamingCell implements Cell {
    */
   @Override
   public CellType getCellTypeEnum() {
-    if(contents == null || type == null) {
+    if(contentsSupplier.getContent() == null || type == null) {
       return CellType.BLANK;
     } else if("n".equals(type)) {
       return CellType.NUMERIC;
@@ -179,7 +178,9 @@ public class StreamingCell implements Cell {
    */
   @Override
   public String getStringCellValue() {
-    return contents == null ? "" : (String) contents;
+    Object c = contentsSupplier.getContent();
+
+    return c == null ? "" : (String) c;
   }
 
   /**
@@ -291,7 +292,7 @@ public class StreamingCell implements Cell {
   @Override
   public CellType getCachedFormulaResultTypeEnum() {
     if (type != null && "str".equals(type)) {
-      if(contents == null || cachedFormulaResultType == null) {
+      if(contentsSupplier.getContent() == null || cachedFormulaResultType == null) {
         return CellType.BLANK;
       } else if("n".equals(cachedFormulaResultType)) {
         return CellType.NUMERIC;

--- a/src/main/java/com/monitorjbl/xlsx/impl/StringSupplier.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StringSupplier.java
@@ -1,0 +1,14 @@
+package com.monitorjbl.xlsx.impl;
+
+class StringSupplier implements Supplier {
+    private final String val;
+
+    StringSupplier(String val) {
+        this.val = val;
+    }
+
+    @Override
+    public Object getContent() {
+        return val;
+    }
+}

--- a/src/main/java/com/monitorjbl/xlsx/impl/Supplier.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/Supplier.java
@@ -1,0 +1,5 @@
+package com.monitorjbl.xlsx.impl;
+
+interface Supplier {
+    Object getContent();
+}


### PR DESCRIPTION
I ran across a performance issue with large spreadsheets, and investigated this using the YourKit profiler.

Two bottlenecks that could be addressed were identified: one is heavy use of a regexp in a function used to split a cell reference string, and the other because of unnecessary formatting of a value, where the formatting could be deferred until if/when the value was actually used.

With my set of files, total processing time went from 944 to 525 seconds with these changes included.

Note to reviewer: the change from regexp to a simplified method when splitting the cell reference works for all tests in the project, and on my testset. If I missed a format that could occur here, please let me know and I will add tests and update the code.