### PR TITLE
Update xerces2 dependency to 2.11.1 due to CVE-2013-4002

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,9 +126,9 @@
       <version>2.11.1</version>
     </dependency>
     <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.4.01</version>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <version>1.4.01</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -121,9 +121,14 @@
       <version>1.3</version>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <version>2.11.0</version>
+      <groupId>com.rackspace.apache</groupId>
+      <artifactId>xerces2-xsd11</artifactId>
+      <version>2.11.1</version>
+    </dependency>
+    <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>1.4.01</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Use rackspace xerces2 package that includes a fix for CVE-2013-4002. See
details in Apache ticket:
    https://issues.apache.org/jira/browse/XERCESJ-1679