### PR TITLE
use poi-ooxml-schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>
-      <artifactId>ooxml-schemas</artifactId>
-      <version>1.3</version>
+      <artifactId>poi-ooxml-schemas</artifactId>
+      <version>3.17</version>
     </dependency>
     <dependency>
       <groupId>com.rackspace.apache</groupId>


### PR DESCRIPTION
currently `poi-ooxml-schemas` is used for apache poi 3.17
however this project used the 1.3 version which could be conflicting