### PR TITLE
start process of removing ctrst class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,19 +133,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.12</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.8.10</version>
+      <version>1.7.25</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.12</version>
+      <version>1.7.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/monitorjbl/xlsx/sst/BufferedStringsTable.java
+++ b/src/main/java/com/monitorjbl/xlsx/sst/BufferedStringsTable.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import java.util.List;
 
 public class BufferedStringsTable extends SharedStringsTable implements AutoCloseable {
-  private final FileBackedList<CTRstImpl> list;
+  private final FileBackedList list;
 
   public static BufferedStringsTable getSharedStringsTable(File tmp, int cacheSize, OPCPackage pkg)
       throws IOException, InvalidFormatException {
@@ -26,7 +26,7 @@ public class BufferedStringsTable extends SharedStringsTable implements AutoClos
   }
 
   private BufferedStringsTable(PackagePart part, File file, int cacheSize) throws IOException {
-    this.list = new FileBackedList<>(CTRstImpl.class, file, cacheSize);
+    this.list = new FileBackedList(file, cacheSize);
     readFrom(part.getInputStream());
   }
 
@@ -52,7 +52,7 @@ public class BufferedStringsTable extends SharedStringsTable implements AutoClos
    * href="https://msdn.microsoft.com/en-us/library/documentformat.openxml.spreadsheet.sharedstringitem.aspx">xmlschema
    * type {@code CT_Rst}</a>.
    */
-  private CTRstImpl parseCT_Rst(XMLEventReader xmlEventReader) throws XMLStreamException {
+  private String parseCT_Rst(XMLEventReader xmlEventReader) throws XMLStreamException {
     // Precondition: pointing to <si>;  Post condition: pointing to </si>
     StringBuilder buf = new StringBuilder();
     XMLEvent xmlEvent;
@@ -72,7 +72,7 @@ public class BufferedStringsTable extends SharedStringsTable implements AutoClos
           throw new IllegalArgumentException(xmlEvent.asStartElement().getName().getLocalPart());
       }
     }
-    return buf.length() > 0 ? new CTRstImpl(buf.toString()) : null;
+    return buf.length() > 0 ? buf.toString() : null;
   }
 
   /**
@@ -105,8 +105,8 @@ public class BufferedStringsTable extends SharedStringsTable implements AutoClos
   }
 
   public CTRst getEntryAt(int idx) {
-    CTRst result = list.getAt(idx);
-    return result != null ? result : CTRstImpl.EMPTY;
+    String result = list.getAt(idx);
+    return result != null ? new CTRstImpl(result) : CTRstImpl.EMPTY;
   }
 
   @Override

--- a/src/main/java/com/monitorjbl/xlsx/sst/CTRstImpl.java
+++ b/src/main/java/com/monitorjbl/xlsx/sst/CTRstImpl.java
@@ -1,9 +1,5 @@
 package com.monitorjbl.xlsx.sst;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.xmlbeans.QNameSet;
 import org.apache.xmlbeans.SchemaType;
 import org.apache.xmlbeans.XmlCursor;
@@ -36,14 +32,12 @@ import java.util.List;
  * to callers that the unit tests pass, but it's very likely that advanced uses
  * of POI datatypes will fail.
  */
-@JsonIgnoreProperties({"nil","rlist","rphList","setT","setPhoneticPr","immutable","domNode","rarray","rphArray", "phoneticPr"})
 public class CTRstImpl implements CTRst {
   public static final CTRst EMPTY = new CTRstImpl("");
 
   private final String string;
 
-  @JsonCreator
-  public CTRstImpl(@JsonProperty("string") String string) {
+  public CTRstImpl(String string) {
     this.string = string;
   }
 
@@ -66,7 +60,6 @@ public class CTRstImpl implements CTRst {
     return string != null;
   }
 
-  @JsonIgnore
   @Override
   public void setT(String s) {
     throw new UnsupportedOperationException();


### PR DESCRIPTION
POI team are trying to remove dependence on the XMLBeans generated class like CTRst.
This change reduces the dependence on this class.
I have a follow up for when POI 4.0.0 is released shortly that will remove the need for that class at all. (https://github.com/pjfanning/excel-streaming-reader/tree/poi-4 and https://github.com/pjfanning/poi-shared-strings)

Relates to https://github.com/monitorjbl/excel-streaming-reader/issues/125