### PR TITLE
Updated version in README pom.xml sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To use it, add this to your POM:
   <dependency>
     <groupId>com.monitorjbl</groupId>
     <artifactId>xlsx-streamer</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
   </dependency>
 </dependencies>  
 ```


### PR DESCRIPTION
I just noticed that the REAME is still referencing `1.2.0` although `1.2.1` is the latest version.