### PR TITLE
Add compatibility features

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/exceptions/MissingSheetException.java
+++ b/src/main/java/com/monitorjbl/xlsx/exceptions/MissingSheetException.java
@@ -1,5 +1,14 @@
 package com.monitorjbl.xlsx.exceptions;
 
+import com.monitorjbl.xlsx.StreamingReader;
+
+/**
+ * Will be thrown by {@link StreamingReader.Builder#read(java.io.File)}, if a sheet is not found.
+ *
+ * @deprecated The POI API {@link org.apache.poi.ss.usermodel.Workbook#getSheet} is designed to return {@code null},
+ * if a sheet is not found. This class will be removed in a future release.
+ */
+@Deprecated
 public class MissingSheetException extends RuntimeException {
 
   public MissingSheetException() {

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingWorkbook.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingWorkbook.java
@@ -1,6 +1,5 @@
 package com.monitorjbl.xlsx.impl;
 
-import com.monitorjbl.xlsx.exceptions.MissingSheetException;
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.formula.udf.UDFFinder;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -28,7 +27,7 @@ public class StreamingWorkbook implements Workbook, AutoCloseable {
 
   int findSheetByName(String name) {
     for(int i = 0; i < reader.getSheetProperties().size(); i++) {
-      if(reader.getSheetProperties().get(i).get("name").equals(name)) {
+      if(reader.getSheetProperties().get(i).get("name").equalsIgnoreCase(name)) {
         return i;
       }
     }
@@ -104,7 +103,8 @@ public class StreamingWorkbook implements Workbook, AutoCloseable {
   public Sheet getSheet(String name) {
     int index = getSheetIndex(name);
     if(index == -1) {
-      throw new MissingSheetException("Sheet '" + name + "' does not exist");
+      // Must return null, if sheet is not found. See {@link org.apache.poi.ss.usermodel.Workbook#getSheet}
+      return null;
     }
     return reader.getSheets().get(index);
   }

--- a/src/test/java/com/monitorjbl/xlsx/StreamingReaderTest.java
+++ b/src/test/java/com/monitorjbl/xlsx/StreamingReaderTest.java
@@ -1,6 +1,20 @@
 package com.monitorjbl.xlsx;
 
-import com.monitorjbl.xlsx.exceptions.MissingSheetException;
+import static org.apache.poi.ss.usermodel.CellType.BOOLEAN;
+import static org.apache.poi.ss.usermodel.CellType.NUMERIC;
+import static org.apache.poi.ss.usermodel.CellType.STRING;
+import static org.apache.poi.ss.usermodel.Row.MissingCellPolicy.CREATE_NULL_AS_BLANK;
+import static org.apache.poi.ss.usermodel.Row.MissingCellPolicy.RETURN_BLANK_AS_NULL;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackageAccess;
 import org.apache.poi.ss.usermodel.Cell;
@@ -25,22 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import static org.apache.poi.ss.usermodel.CellType.BOOLEAN;
-import static org.apache.poi.ss.usermodel.CellType.NUMERIC;
-import static org.apache.poi.ss.usermodel.CellType.STRING;
-import static org.apache.poi.ss.usermodel.Row.MissingCellPolicy.CREATE_NULL_AS_BLANK;
-import static org.apache.poi.ss.usermodel.Row.MissingCellPolicy.RETURN_BLANK_AS_NULL;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 
 public class StreamingReaderTest {
   @BeforeClass
@@ -384,14 +382,26 @@ public class StreamingReaderTest {
     }
   }
 
-  @Test(expected = MissingSheetException.class)
+  @Test
+  public void testSheetName_ignoreCase() throws Exception {
+    try (
+        InputStream is = new FileInputStream(new File("src/test/resources/sheets.xlsx"));
+        Workbook wb = StreamingReader.builder().open(is)
+    )
+    {
+      Sheet sheet = wb.getSheet("sheetalpha");
+      assertThat(sheet, is(notNullValue()));
+    }
+  }
+
+  @Test
   public void testSheetName_missingInStream() throws Exception {
     try(
         InputStream is = new FileInputStream(new File("src/test/resources/sheets.xlsx"));
-        Workbook wb = StreamingReader.builder().open(is);
+        Workbook wb = StreamingReader.builder().open(is)
     ) {
-      wb.getSheet("asdfasdfasdf");
-      fail("Should have failed");
+      Sheet sheet = wb.getSheet("asdfasdfasdf");
+      assertThat(sheet, is(nullValue()));
     }
   }
 
@@ -399,10 +409,9 @@ public class StreamingReaderTest {
   public void testSheetName_missingInFile() throws Exception {
     File f = new File("src/test/resources/sheets.xlsx");
     try(Workbook wb = StreamingReader.builder().open(f)) {
-      wb.getSheet("asdfasdfasdf");
-      fail("Should have failed");
-    } catch(MissingSheetException e) {
       assertTrue(f.exists());
+      Sheet sheet = wb.getSheet("asdfasdfasdf");
+      assertThat(sheet, is(nullValue()));
     }
   }
 


### PR DESCRIPTION
- Mark MissingSheetException as deprecated and return null instead.
  The POI API does not know that kind of exception.

- Ignore case in search sheet by name.