### PR TITLE
Fix npe empty cells

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/sst/BufferedStringsTable.java
+++ b/src/main/java/com/monitorjbl/xlsx/sst/BufferedStringsTable.java
@@ -73,7 +73,7 @@ public class BufferedStringsTable extends SharedStringsTable implements AutoClos
           throw new IllegalArgumentException(xmlEvent.asStartElement().getName().getLocalPart());
       }
     }
-    return buf.length() > 0 ? buf.toString() : null;
+    return buf.length() > 0 ? buf.toString() : "";
   }
 
   /**

--- a/src/main/java/com/monitorjbl/xlsx/sst/BufferedStringsTable.java
+++ b/src/main/java/com/monitorjbl/xlsx/sst/BufferedStringsTable.java
@@ -73,7 +73,7 @@ public class BufferedStringsTable extends SharedStringsTable implements AutoClos
           throw new IllegalArgumentException(xmlEvent.asStartElement().getName().getLocalPart());
       }
     }
-    return buf.length() > 0 ? buf.toString() : "";
+    return buf.length() > 0 ? buf.toString() : null;
   }
 
   /**

--- a/src/main/java/com/monitorjbl/xlsx/sst/FileBackedList.java
+++ b/src/main/java/com/monitorjbl/xlsx/sst/FileBackedList.java
@@ -49,7 +49,9 @@ public class FileBackedList implements AutoCloseable {
 
   public void add(String str) {
     try {
-      writeToFile(str);
+      if (str!=null && str.length()>0) {
+        writeToFile(str);
+      }
     } catch(IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
We have tried to read a very large file 500K records , with lots of columns. so we used the SST cache
not to overload memory with the shared string table. 

some columns have empty values. this caused a NPE cause the write to sst cache file was trying to 
read the bytes length from the string , and was not protection of null 