### PR TITLE
added StreaminCell.getRawContents()

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingCell.java
@@ -52,6 +52,12 @@ public class StreamingCell implements Cell {
     this.use1904Dates = use1904Dates;
   }
 
+    public Object getRawContents() {
+        return rawContents;
+    }
+    
+    
+
   public void setContentSupplier(Supplier contentsSupplier) {
     this.contentsSupplier = contentsSupplier;
   }


### PR DESCRIPTION
our customers usually upload excel files with phone numbers in numeric cells. Getting the raw content is the only healthy way to get the phone number, without any modification. I'm sure many will find the rawContents to be the solution in hopeless cases