### PR TITLE
Support StreamingSheet.getWorkbook allowing DataFormater use

### DIFF
--- a/src/main/java/com/monitorjbl/xlsx/StreamingReader.java
+++ b/src/main/java/com/monitorjbl/xlsx/StreamingReader.java
@@ -247,9 +247,11 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
      * @throws com.monitorjbl.xlsx.exceptions.ReadException if there is an issue reading the stream
      */
     public Workbook open(InputStream is) {
-      StreamingWorkbookReader workbook = new StreamingWorkbookReader(this);
-      workbook.init(is);
-      return new StreamingWorkbook(workbook);
+      StreamingWorkbookReader workbookReader = new StreamingWorkbookReader(this);
+      StreamingWorkbook streamingWorkbook = new StreamingWorkbook(workbookReader);
+      workbookReader.setStreamingWorkbook(streamingWorkbook);
+      workbookReader.init(is);
+      return streamingWorkbook;
     }
 
     /**
@@ -262,9 +264,11 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
      * @throws com.monitorjbl.xlsx.exceptions.ReadException if there is an issue reading the file
      */
     public Workbook open(File file) {
-      StreamingWorkbookReader workbook = new StreamingWorkbookReader(this);
-      workbook.init(file);
-      return new StreamingWorkbook(workbook);
+      StreamingWorkbookReader workbookReader = new StreamingWorkbookReader(this);
+      StreamingWorkbook streamingWorkbook = new StreamingWorkbook(workbookReader);
+      workbookReader.setStreamingWorkbook(streamingWorkbook);
+      workbookReader.init(file);
+      return streamingWorkbook;
     }
 
     /**
@@ -350,7 +354,7 @@ public class StreamingReader implements Iterable<Row>, AutoCloseable {
 
         XMLEventReader parser = StaxHelper.newXMLInputFactory().createXMLEventReader(sheet);
 
-        return new StreamingReader(new StreamingWorkbookReader(sst, sstCache, pkg, new StreamingSheetReader(sst, styles, parser, use1904Dates, rowCacheSize),
+        return new StreamingReader(new StreamingWorkbookReader(sst, sstCache, pkg, new StreamingSheetReader(null, sst, styles, parser, use1904Dates, rowCacheSize),
             this));
       } catch(IOException e) {
         throw new OpenException("Failed to open file", e);

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheet.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheet.java
@@ -854,7 +854,7 @@ public class StreamingSheet implements Sheet {
    */
   @Override
   public Workbook getWorkbook() {
-    throw new UnsupportedOperationException();
+    return reader.getStreamingWorkbook();
   }
 
   /**

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheetReader.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingSheetReader.java
@@ -32,6 +32,8 @@ import java.util.Set;
 public class StreamingSheetReader implements Iterable<Row> {
   private static final Logger log = LoggerFactory.getLogger(StreamingSheetReader.class);
 
+
+  private final StreamingWorkbook streamingWorkbook;
   private final SharedStringsTable sst;
   private final StylesTable stylesTable;
   private final XMLEventReader parser;
@@ -52,8 +54,9 @@ public class StreamingSheetReader implements Iterable<Row> {
   private StreamingCell currentCell;
   private boolean use1904Dates;
 
-  public StreamingSheetReader(SharedStringsTable sst, StylesTable stylesTable, XMLEventReader parser,
+  public StreamingSheetReader(StreamingWorkbook streamingWorkbook, SharedStringsTable sst, StylesTable stylesTable, XMLEventReader parser,
                               final boolean use1904Dates, int rowCacheSize) {
+    this.streamingWorkbook = streamingWorkbook;
     this.sst = sst;
     this.stylesTable = stylesTable;
     this.parser = parser;
@@ -63,6 +66,10 @@ public class StreamingSheetReader implements Iterable<Row> {
 
   void setSheet(StreamingSheet sheet) {
     this.sheet = sheet;
+  }
+
+  public StreamingWorkbook getStreamingWorkbook() {
+    return streamingWorkbook;
   }
 
   /**

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingWorkbook.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingWorkbook.java
@@ -4,23 +4,15 @@ import com.monitorjbl.xlsx.exceptions.MissingSheetException;
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.formula.EvaluationWorkbook;
 import org.apache.poi.ss.formula.udf.UDFFinder;
-import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.CreationHelper;
-import org.apache.poi.ss.usermodel.DataFormat;
-import org.apache.poi.ss.usermodel.Font;
-import org.apache.poi.ss.usermodel.Name;
-import org.apache.poi.ss.usermodel.PictureData;
+import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.usermodel.Row.MissingCellPolicy;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.SheetVisibility;
-import org.apache.poi.ss.usermodel.Workbook;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
 import java.util.List;
 
-public class StreamingWorkbook implements Workbook, AutoCloseable {
+public class StreamingWorkbook implements Workbook, Date1904Support, AutoCloseable {
   private final StreamingWorkbookReader reader;
 
   public StreamingWorkbook(StreamingWorkbookReader reader) {
@@ -503,6 +495,11 @@ public class StreamingWorkbook implements Workbook, AutoCloseable {
   @Override
   public int addOlePackage(byte[] bytes, String s, String s1, String s2) throws IOException {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isDate1904() {
+    return reader.isUse1904Dates();
   }
 
   @Override

--- a/src/main/java/com/monitorjbl/xlsx/impl/StreamingWorkbookReader.java
+++ b/src/main/java/com/monitorjbl/xlsx/impl/StreamingWorkbookReader.java
@@ -52,6 +52,7 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, AutoCloseable {
   private OPCPackage pkg;
   private SharedStringsTable sst;
   private boolean use1904Dates = false;
+  private StreamingWorkbook streamingWorkbook;
 
   /**
    * This constructor exists only so the StreamingReader can instantiate
@@ -80,6 +81,10 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, AutoCloseable {
 
   public StreamingSheetReader first() {
     return sheets.get(0).getReader();
+  }
+
+  public void setStreamingWorkbook(StreamingWorkbook streamingWorkbook) {
+    this.streamingWorkbook = streamingWorkbook;
   }
 
   public void init(InputStream is) {
@@ -159,7 +164,8 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, AutoCloseable {
     int i = 0;
     for(URI uri : sheetStreams.keySet()) {
       XMLEventReader parser = StaxHelper.newXMLInputFactory().createXMLEventReader(sheetStreams.get(uri));
-      sheets.add(new StreamingSheet(sheetProperties.get(i++).get("name"), new StreamingSheetReader(sst, stylesTable, parser, use1904Dates, rowCacheSize)));
+      sheets.add(new StreamingSheet(sheetProperties.get(i++).get("name"),
+      new StreamingSheetReader(streamingWorkbook, sst, stylesTable, parser, use1904Dates, rowCacheSize)));
     }
   }
 
@@ -211,6 +217,10 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, AutoCloseable {
         sstCache.delete();
       }
     }
+  }
+
+  public boolean isUse1904Dates() {
+    return use1904Dates;
   }
 
   static class StreamingSheetIterator implements Iterator<Sheet> {

--- a/src/test/java/com/monitorjbl/xlsx/DataFormatterTest.java
+++ b/src/test/java/com/monitorjbl/xlsx/DataFormatterTest.java
@@ -1,0 +1,12 @@
+package com.monitorjbl.xlsx;
+
+import org.apache.poi.ss.usermodel.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Locale;
+
+
+public class DataFormatterTest {
+
+}

--- a/src/test/java/com/monitorjbl/xlsx/StreamingReaderTest.java
+++ b/src/test/java/com/monitorjbl/xlsx/StreamingReaderTest.java
@@ -3,12 +3,7 @@ package com.monitorjbl.xlsx;
 import com.monitorjbl.xlsx.exceptions.MissingSheetException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackageAccess;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CellType;
-import org.apache.poi.ss.usermodel.DateUtil;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -215,6 +210,50 @@ public class StreamingReaderTest {
         obj.get(0).get(0).getDateCellValue();
         fail("Should have thrown IllegalStateException");
       } catch(IllegalStateException e) { }
+    }
+  }
+
+  @Test
+  public void testDataFormatter1900() throws Exception {
+    try(
+        InputStream is = new FileInputStream(new File("src/test/resources/data_types.xlsx"));
+        Workbook wb = StreamingReader.builder().open(is);
+    ) {
+
+      List<List<Cell>> obj = new ArrayList<>();
+
+      for(Row r : wb.getSheetAt(0)) {
+        List<Cell> o = new ArrayList<>();
+        for(Cell c : r) {
+          o.add(c);
+        }
+        obj.add(o);
+      }
+
+      DataFormatter dataFormatter = new DataFormatter(Locale.ENGLISH);
+      assertEquals("1/1/2014", dataFormatter.formatCellValue(obj.get(4).get(1)));
+    }
+  }
+
+  @Test
+  public void testDataFormatter1904() throws Exception {
+    try(
+        InputStream is = new FileInputStream(new File("src/test/resources/1904Dates.xlsx"));
+        Workbook wb = StreamingReader.builder().open(is);
+    ) {
+
+      List<List<Cell>> obj = new ArrayList<>();
+
+      for(Row r : wb.getSheetAt(0)) {
+        List<Cell> o = new ArrayList<>();
+        for(Cell c : r) {
+          o.add(c);
+        }
+        obj.add(o);
+      }
+
+      DataFormatter dataFormatter = new DataFormatter(Locale.ENGLISH);
+      assertEquals("10/14/1991", dataFormatter.formatCellValue(obj.get(1).get(5)));
     }
   }
 


### PR DESCRIPTION
Small patch with test to allow DataFormater to be used.

DataFormater required StreamingSheet.getWorkbook and detects the Date1904Support interface.

Note the deprecated StreamingReader.read(File f) method is not supported.